### PR TITLE
Allow tracker pause and resume

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -214,6 +214,7 @@ class BaseEmissionsTracker(ABC):
         self._measure_occurrence: int = 0
         self._cloud = None
         self._previous_emissions = None
+        self.pause_count = 0
 
         if isinstance(self._gpu_ids, str):
             self._gpu_ids = parse_gpu_ids(self._gpu_ids)
@@ -338,10 +339,20 @@ class BaseEmissionsTracker(ABC):
         Logs intermediate experiment tracking results.
         :return: CO2 emissions in kgs
         """
+        # check if csv already exists
+        if self._save_to_file and os.path.exists(
+            os.path.join(self._output_dir, self._output_file)
+        ):
+            self.pause_count += 1
+            filename, extension = os.path.splitext(self._output_file)
+            new_filename = f"{filename}_{self.pause_count}"
+            self.persistence_objs[0] = FileOutput(
+                os.path.join(self._output_dir, f"{new_filename}{extension}")
+            )
         return self._stop(destroy=False)
 
     @suppress(Exception)
-    def restart(self):
+    def resume(self):
         """
         Restarts
         """

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -355,7 +355,7 @@ class BaseEmissionsTracker(ABC):
     @suppress(Exception)
     def resume(self):
         """
-        Restarts
+        Resumes previously paused tracking
         """
         logger.info("Restarting tracker")
         self._last_measured_time = self._start_time = time.time()

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -317,6 +317,16 @@ class BaseEmissionsTracker(ABC):
         else:
             self._scheduler.pause()
 
+        if self._save_to_file and os.path.exists(
+            os.path.join(self._output_dir, self._output_file)
+        ):
+            self.pause_count += 1
+            filename, extension = os.path.splitext(self._output_file)
+            new_filename = f"{filename}_{self.pause_count}"
+            self.persistence_objs[0] = FileOutput(
+                os.path.join(self._output_dir, f"{new_filename}{extension}")
+            )
+
         # Run to calculate the power used from last
         # scheduled measurement to shutdown
         self._measure_power()
@@ -340,15 +350,6 @@ class BaseEmissionsTracker(ABC):
         :return: CO2 emissions in kgs
         """
         # check if csv already exists
-        if self._save_to_file and os.path.exists(
-            os.path.join(self._output_dir, self._output_file)
-        ):
-            self.pause_count += 1
-            filename, extension = os.path.splitext(self._output_file)
-            new_filename = f"{filename}_{self.pause_count}"
-            self.persistence_objs[0] = FileOutput(
-                os.path.join(self._output_dir, f"{new_filename}{extension}")
-            )
         return self._stop(destroy=False)
 
     @suppress(Exception)

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -214,7 +214,6 @@ class BaseEmissionsTracker(ABC):
         self._measure_occurrence: int = 0
         self._cloud = None
         self._previous_emissions = None
-        self.pause_count = 0
 
         if isinstance(self._gpu_ids, str):
             self._gpu_ids = parse_gpu_ids(self._gpu_ids)
@@ -317,16 +316,6 @@ class BaseEmissionsTracker(ABC):
         else:
             self._scheduler.pause()
 
-        if self._save_to_file and os.path.exists(
-            os.path.join(self._output_dir, self._output_file)
-        ):
-            self.pause_count += 1
-            filename, extension = os.path.splitext(self._output_file)
-            new_filename = f"{filename}_{self.pause_count}"
-            self.persistence_objs[0] = FileOutput(
-                os.path.join(self._output_dir, f"{new_filename}{extension}")
-            )
-
         # Run to calculate the power used from last
         # scheduled measurement to shutdown
         self._measure_power()
@@ -349,7 +338,6 @@ class BaseEmissionsTracker(ABC):
         Logs intermediate experiment tracking results.
         :return: CO2 emissions in kgs
         """
-        # check if csv already exists
         return self._stop(destroy=False)
 
     @suppress(Exception)


### PR DESCRIPTION
This PR allows pausing and restarting of the carbon emissions tracker.

```python
from codecarbon import EmissionsTracker

tracker = EmissionsTracker()
# start
tracker.start()
# pause
tracker.pause()
# resume
tracker.resume()
# pause again
tracker.pause()
# resume again
tracker.resume()
# stop
tracker.stop()
```

Each `.pause()` call will dump tracked statistics in a CSV file. If `emissions.csv` already exists due to a previous pause, the next CSV will be titled `emissions_1.csv`, the next next, `emissions_2.csv`, etc. 

In the Megatron-DeepSpeed codebase, we could do

```python
def codecarbon_tracker_pause():
    global _GLOBAL_CODECARBON_TRACKER
    if _GLOBAL_CODECARBON_TRACKER is None:
        return

    print('codecarbon STOP')
    _GLOBAL_CODECARBON_TRACKER.pause()


def codecarbon_tracker_resume():
    global _GLOBAL_CODECARBON_TRACKER
    if _GLOBAL_CODECARBON_TRACKER is None:
        return

    print('codecarbon STOP')
    _GLOBAL_CODECARBON_TRACKER.resume()

def codecarbon_tracker_restart():
    global _GLOBAL_CODECARBON_TRACKER
    if _GLOBAL_CODECARBON_TRACKER is None:
        return

    codecarbon_tracker_pause()
    codecarbon_tracker_resume()
```